### PR TITLE
Map colormap of data

### DIFF
--- a/include/cppcolormap.h
+++ b/include/cppcolormap.h
@@ -185,7 +185,7 @@ namespace detail {
             size_t N = data.dimension();
             std::vector<size_t> shape(N + 1);
             std::copy(data.shape().cbegin(), data.shape().cend(), shape.begin());
-            shape[N] = 3;
+            shape[N] = colors.shape(1);
             xt::xarray<T> ret = xt::empty<T>(shape);
             as_colors_func(data, colors, vmin, vmax, ret);
             return ret;
@@ -207,7 +207,7 @@ namespace detail {
         {
             std::array<size_t, N + 1> shape;
             std::copy(data.shape().cbegin(), data.shape().cend(), shape.begin());
-            shape[N] = 3;
+            shape[N] = colors.shape(1);
             xt::xtensor<T, N + 1> ret = xt::empty<T>(shape);
             detail::as_colors_func(data, colors, vmin, vmax, ret);
             return ret;

--- a/python/main.cpp
+++ b/python/main.cpp
@@ -242,6 +242,30 @@ m.def("rgb2hex",
     py::overload_cast<const xt::xtensor<double,1>&>(&cppcolormap::rgb2hex),
     "Convert rgb -> hex");
 
+m.def("as_colors", [](
+        const xt::xarray<double>& data,
+        const xt::xtensor<double, 2>& colors,
+        double vmin,
+        double vmax) {
+            return cppcolormap::as_colors(data, colors, vmin, vmax);
+    },
+    "Convert data to colors using a colormap."
+    "See :cpp:func:`cppcolormap::as_colors`.",
+    py::arg("data"),
+    py::arg("colors"),
+    py::arg("vmin"),
+    py::arg("vmax"));
+
+m.def("as_colors", [](
+        const xt::xarray<double>& data,
+        const xt::xtensor<double, 2>& colors) {
+            return cppcolormap::as_colors(data, colors);
+    },
+    "Convert data to colors using a colormap."
+    "See :cpp:func:`cppcolormap::as_colors`.",
+    py::arg("data"),
+    py::arg("colors"));
+
 // -------------------------------------------------------------------------------------------------
 
 py::enum_<cppcolormap::metric>(m, "metric", "Distance metric for color matching")


### PR DESCRIPTION
Here is a first proposal @davidbrochart . Please feel free to comment.

This allows for the following

```cpp
    auto c = cppcolormap::Greys(5);
    xt::xtensor<double, 1> data = {0, 1, 2, 3, 4};
    std::cout << cppcolormap::as_colors(data, c) << std::endl;
```

Fixes https://github.com/tdegeus/cppcolormap/issues/24

P.S. I should probably introduce tests. In contrast to the colormaps this is something that could actually go wrong.